### PR TITLE
Minor updates to get the project compiling again and bring it to a slightly newer version of Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.0.1.RELEASE</version>
+		<version>1.1.8.RELEASE</version>
 	</parent>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>
 			<artifactId>spring-security-oauth2</artifactId>
-			<version>2.0.0.BUILD-SNAPSHOT</version>
+			<version>2.0.4.RELEASE</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>jackson-mapper-asl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,33 +65,4 @@
 		</plugins>
 	</build>
 
-	<repositories>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
-
 </project>


### PR DESCRIPTION
Hi Dave.

In case you want them, here are a couple of fixes to your sparklr-boot project. Switched to spring-security-oauth 2.0.4.RELEASE, as the snapshot dependency had changed, causing the project to fail to compile. Also brought it up to Spring Boot 1.1.8.

Note - I tried to bring it up to Spring Boot 1.1.9, but it would appear that against that version, the AuthenticationManageBuilder is returning a null AuthenticationManager, causing multiple tests to fail. I have spent some time debugging through it, but I'm not familiar with Boot's internals, and so far I haven't worked out the root cause why that is. Hopefully that's not a bug in 1.1.9.

Steve
